### PR TITLE
Update SXT_TweakScale.cfg

### DIFF
--- a/GameData/SXT/Patches/ModCompatibility/SXT_TweakScale.cfg
+++ b/GameData/SXT/Patches/ModCompatibility/SXT_TweakScale.cfg
@@ -103,7 +103,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 {
 	%MODULE[TweakScale]
 	{
-        type = stack
+        type = stack_square
         defaultScale = 1.25
 	}
 }
@@ -111,7 +111,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 {
 	%MODULE[TweakScale]
 	{
-        type = stack
+        type = stack_square
         defaultScale = 1.25
 	}
 }
@@ -119,7 +119,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 {
 	%MODULE[TweakScale]
 	{
-        type = stack
+        type = stack_square
         defaultScale = 0.625
 	}
 }
@@ -127,88 +127,64 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 {
 	%MODULE[TweakScale]
 	{
-        type = stack
+        type = stack_square
         defaultScale = 2.5
-	}
-}
-@PART[SXTWingSmall]:NEEDS[TweakScale] 
-{
-	%MODULE[TweakScale]
-	{
-        type = surface
-        defaultScale = 1.25
-	}
-}
-@PART[SXTWingLarge]:NEEDS[TweakScale] 
-{
-	%MODULE[TweakScale]
-	{
-        type = surface
-        defaultScale = 1.25
 	}
 }
 @PART[SXTOMS]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[RCSBoonExt]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTRCSRack]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTVernier885]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTDepolyRTGII]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTDepolyRTGI]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTsolarPanelhex]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free_square
 	}
 }
 @PART[SXTsolarPanelLarge]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free_square
 	}
 }
 @PART[SXTKe90TurboJet]:NEEDS[TweakScale] 
@@ -319,16 +295,14 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTAirbagSmall]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTPipeGLong]:NEEDS[TweakScale] 
@@ -479,8 +453,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTBalloon]:NEEDS[TweakScale] 
@@ -611,14 +584,6 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
         defaultScale = 2.5
 	}
 }
-@PART[SXTOsaulNoseCockpitAn225]:NEEDS[TweakScale] 
-{
-	%MODULE[TweakScale]
-	{
-        type = stack
-        defaultScale = 3.75
-	}
-}
 @PART[SXTOsualHullLarge]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
@@ -627,37 +592,27 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
         defaultScale = 3.75
 	}
 }
-
-@PART[SXTOsualRadCockpit]:NEEDS[TweakScale] 
-{
-	%MODULE[TweakScale]
-	{
-        type = surface
-        defaultScale = 1.25
-	}
-}
 @PART[SXTOsualRadHull]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = stack
+        defaultScale = 3.75
 	}
 }
 @PART[SXTOsualRadHullEnd]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = stack
+        defaultScale = 3.75
 	}
 }
 @PART[SXTradialFuel]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
-        type = surface
-        defaultScale = 1.25
+        type = free
 	}
 }
 @PART[SXTDLK83EHabitat]:NEEDS[TweakScale] 
@@ -899,14 +854,14 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 {
 	%MODULE[TweakScale]
 	{
-        type = free
+        type = free_square
 	}
 }
 @PART[SXTWing*]:NEEDS[TweakScale] // 6 parts
 {
 	%MODULE[TweakScale]
 	{
-        type = free
+        type = free_square
 	}
 }
 @PART[SXTAirbrake*]:NEEDS[TweakScale] // 3 parts
@@ -970,7 +925,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
     #@TWEAKSCALEBEHAVIOR[Engine]/MODULE[TweakScale] { }
     %MODULE[TweakScale]
     {
-        type = surface
+        type = free
     }
 }
 
@@ -999,7 +954,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
     #@TWEAKSCALEBEHAVIOR[Engine]/MODULE[TweakScale] { }
     %MODULE[TweakScale]
     {
-        type = stack
+        type = stack_square
         defaultScale = 2.5
     }
 }
@@ -1049,15 +1004,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 {
     %MODULE[TweakScale]
     {
-        type = surface
-    }
-}
-@PART[SXTInlineAirIntake]:NEEDS[TweakScale] 
-{
-    %MODULE[TweakScale]
-    {
-        type = stack
-        defaultScale = 1.25
+        type = free_square
     }
 }
 @PART[SXTSmallFuselage]:NEEDS[TweakScale] 


### PR DESCRIPTION
- Removed Osaul cockpit duplicates, corrected defaultscale on the Osaul radial (aka Yavka) parts to 3.75.
- SXTWingSmall and -Large are covered by SXTWing*, removed.
- Switched wing and elevon scaletypes to free_square to be in line with stock wings (mass increases squared).
- Replaced type=surface scaletypes with more appropriate ones (surface scalefactors don't work well with defaultscale=1.25).
- Switch air intakes from stack to stack_squared (or free_squared) to be in line with stock intakes.
- Removed [SXTInlineAirIntake] duplicate.